### PR TITLE
Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build pc-ble-driver-py
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        path: pc-ble-driver-py
+
+    - name: Checkout pc-ble-driver
+      uses: actions/checkout@v3
+      with:
+        repository: NordicSemiconductor/pc-ble-driver
+        ref: c0ffd419053e2405fffdb02ce7f1f9acceff4a66
+        path: pc-ble-driver
+    
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y cmake build-essential python3-dev libspdlog-dev libasio-dev libudev-dev python3-pip && pip3 install scikit-build
+
+    - name: Compile pc-ble-driver
+      working-directory: pc-ble-driver
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug -DDISABLE_TESTS=1 -DNRF_BLE_DRIVER_VERSION=4.1.100 -G "Unix Makefiles" ..
+        make nrf_ble_driver_sd_api_v5_static
+        sudo make install
+
+    - name: Build pc-ble-driver-py wheels
+      working-directory: pc-ble-driver-py
+      run: |
+        python setup.py bdist_wheel --build-type Release
+  
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: pc_ble_driver_py-linux
+        path: "pc-ble-driver-py/dist/*.whl"
+        if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if(WIN32)
 endif()
 
 set(PC_BLE_DRIVER_PY_OUTDIR ${CMAKE_BINARY_DIR}/outdir)
-set(NRF_BLE_DRIVER_VERSION "4.1.4")
+set(NRF_BLE_DRIVER_VERSION "4.1.100")
 
 # There is no reason to compile more than two SoftDevice API versions
 # The Python module only supports one SoftDevice API


### PR DESCRIPTION
The workflow checkouts specific commit of `pc-ble-driver` library, compiles it and then builds `pc-ble-driver-py` library using just compiled version of `pc-ble-driver`.

The workflow stores wheels for Python 3.8 and 3.10 and only for Linux platform. Ubuntu 20.04 and Ubuntu 22.04 images are used as build environment.