### PR TITLE
publish release to pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, macos-latest, windows-2019 ]
+        os: [ ubuntu-20.04, ubuntu-22.04]  # , macos-latest, windows-2019 
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         include:
           - python-version: '3.8'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,10 +113,13 @@ jobs:
           find dist -name '*.whl' -exec mv {} dist \;
           find dist -type d -empty -delete
           ls -R dist
+      - name: make linux wheels pypi compatible
+        working-directory: dist
+        run: |
           # convert linux wheels to manylinux format
-          docker run --rm -v `pwd`/dist:/io -w /io quay.io/pypa/manylinux1_x86_64 auditwheel repair pc_ble_driver_py_com-0.17.1-cp310-cp310-linux_x86_64.whl -w /io/
+          find . -name '*linux*.whl' -exec docker run --rm -v `pwd`:/io -w /io quay.io/pypa/manylinux1_x86_64 auditwheel repair {} -w /io/
           # drop unsupported wheels
-          rm dist/*-linux*.whl
+          rm *-linux*.whl
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,5 +108,6 @@ jobs:
         uses: actions/download-artifact@v3
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
-        packages-dir: pc-ble-driver-py/dist/
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: pc-ble-driver-py/dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04]  # , macos-latest, windows-2019 
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-latest, windows-2019 ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         include:
           - python-version: '3.8'
@@ -120,11 +120,12 @@ jobs:
 
           # list files
           ls -R dist
-      # retrieve your distributions here
+      
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+
       - name: upload release assets
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,13 +112,13 @@ jobs:
         run: |
           find dist -name '*.whl' -exec mv {} dist \;
           find . -type d -empty -delete
-      - name: upload release assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: dist/*.whl
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: dist/      
+          packages-dir: dist/
+      - name: upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,6 @@ jobs:
         path: "pc-ble-driver-py/dist/*.whl"
         if-no-files-found: error
   pypi-publish:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: build
     name: upload release to PyPI
     runs-on: ubuntu-latest
@@ -111,18 +110,28 @@ jobs:
           path: dist
       - name: flatten folder structure
         run: |
+          ls -R dist
           find dist -name '*.whl' -exec mv {} dist \;
           find dist -type d -empty -delete
+          ls -R dist
           # convert linux wheels to manylinux format
           docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*ubuntu*.whl -w /io/
           # drop unsupported wheels
           rm dist/*-ubuntu*.whl
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+      - name: Test Publishing distributions to PyPI
+        if: github.event_name == 'pull_request'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
       - name: upload release assets
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: softprops/action-gh-release@v1
         with:
           files: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
           find dist -type d -empty -delete
           ls -R dist
           # convert linux wheels to manylinux format
-          docker run --rm -v `pwd`/dist:/io -w /io quay.io/pypa/manylinux1_x86_64 auditwheel repair *.whl -w /io/
+          docker run --rm -v `pwd`/dist:/io -w /io quay.io/pypa/manylinux1_x86_64 auditwheel repair pc_ble_driver_py_com-0.17.1-cp310-cp310-linux_x86_64.whl -w /io/
           # drop unsupported wheels
           rm dist/*-linux*.whl
       # retrieve your distributions here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,3 +117,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          repository-url: https://pypi.org/p/pc-ble-driver-py-com
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,14 +112,11 @@ jobs:
         run: |
           find dist -name '*.whl' -exec mv {} dist \;
           find dist -type d -empty -delete
-          ls -R dist
-      - name: make linux wheels pypi compatible
-        working-directory: dist
-        run: |
-          # convert linux wheels to manylinux format
-          find . -name '*linux*.whl' -exec docker run --rm -v `pwd`:/io -w /io quay.io/pypa/manylinux2014_x86_64 auditwheel repair {} -w /io/ \;
+          
           # drop unsupported wheels
           rm *-linux*.whl
+          # list files
+          ls -R dist
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         working-directory: dist
         run: |
           # convert linux wheels to manylinux format
-          find . -name '*linux*.whl' -exec docker run --rm -v `pwd`:/io -w /io quay.io/pypa/manylinux1_x86_64 auditwheel repair {} -w /io/
+          find . -name '*linux*.whl' -exec docker run --rm -v `pwd`:/io -w /io quay.io/pypa/manylinux2014_x86_64 auditwheel repair {} -w /io/
           # drop unsupported wheels
           rm *-linux*.whl
       # retrieve your distributions here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
           find dist -name '*.whl' -exec mv {} dist \;
           find dist -type d -empty -delete
           # convert linux wheels to manylinux format
-          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*.linux*.whl -w /io/wheelhouse/
+          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*linux*.whl -w /io/
           # drop unsupported wheels
           rm dist/*-linux*.whl
       # retrieve your distributions here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,7 @@ jobs:
         if-no-files-found: error
   pypi-publish:
     needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     name: upload release to PyPI
     runs-on: ubuntu-latest
     permissions:
@@ -113,25 +114,18 @@ jobs:
           find dist -name '*.whl' -exec mv {} dist \;
           find dist -type d -empty -delete
           
-          # drop unsupported wheels
+          # linux wheels at the moment are not pypi/manylinux compatible
+          # drop unsupported wheels.
           rm *-linux*.whl
+
           # list files
           ls -R dist
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-      - name: Test Publishing distributions to PyPI
-        if: github.event_name == 'pull_request'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-          repository-url: https://test.pypi.org/legacy/
       - name: upload release assets
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: softprops/action-gh-release@v1
         with:
           files: dist/*
-          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,7 +111,8 @@ jobs:
       - name: flatten folder structure
         run: |
           find dist -name '*.whl' -exec mv {} dist \;
-          find . -type d -empty -delete
+          find dist -type d -empty -delete
+          rm dist/*linux*.whl
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,9 @@ jobs:
     steps:
       - name: Upload artifacts
         uses: actions/download-artifact@v3
+        with:
+          path: pc-ble-driver-py/dist/
+        
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,10 +112,13 @@ jobs:
         run: |
           find dist -name '*.whl' -exec mv {} dist \;
           find . -type d -empty -delete
+      - name: upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*.whl
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: dist/
-          repository-url: https://pypi.org/p/pc-ble-driver-py-com/
+          packages-dir: dist/      
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,13 +104,14 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - name: Upload artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          path: pc-ble-driver-py/dist/
-        
+          path: dist
+      - name: flatten folder structure
+        run: find dist -name '*.whl' -exec cp {} dist \;
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: pc-ble-driver-py/dist/
+          packages-dir: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
           find dist -type d -empty -delete
           ls -R dist
           # convert linux wheels to manylinux format
-          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux1_x86_64 auditwheel repair /io/*linux*.whl -w /io/
+          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux1_x86_64 ls /io && auditwheel repair /io/*linux*.whl -w /io/
           # drop unsupported wheels
           rm dist/*-linux*.whl
       # retrieve your distributions here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+      contents: write
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -112,7 +113,10 @@ jobs:
         run: |
           find dist -name '*.whl' -exec mv {} dist \;
           find dist -type d -empty -delete
-          rm dist/*linux*.whl
+          # convert linux wheels to manylinux format
+          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*.linux*.whl -w /io/wheelhouse/
+          # drop unsupported wheels
+          rm dist/*-linux*.whl
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         working-directory: dist
         run: |
           # convert linux wheels to manylinux format
-          find . -name '*linux*.whl' -exec docker run --rm -v `pwd`:/io -w /io quay.io/pypa/manylinux2014_x86_64 auditwheel repair {} -w /io/
+          find . -name '*linux*.whl' -exec docker run --rm -v `pwd`:/io -w /io quay.io/pypa/manylinux2014_x86_64 auditwheel repair {} -w /io/ \;
           # drop unsupported wheels
           rm *-linux*.whl
       # retrieve your distributions here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
 env:
   NRF_BLE_DRIVER_VERSION: 4.1.100
 jobs:
@@ -93,3 +95,18 @@ jobs:
         name: pc_ble_driver_py-${{ matrix.os }}-${{ matrix.toxpy}}
         path: "pc-ble-driver-py/dist/*.whl"
         if-no-files-found: error
+  pypi-publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: build
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - name: Upload artifacts
+        uses: actions/download-artifact@v3
+      # retrieve your distributions here
+      - name: Publish package distributions to PyPI
+        packages-dir: pc-ble-driver-py/dist/
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,9 +114,9 @@ jobs:
           find dist -name '*.whl' -exec mv {} dist \;
           find dist -type d -empty -delete
           # convert linux wheels to manylinux format
-          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*linux*.whl -w /io/
+          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*ubuntu*.whl -w /io/
           # drop unsupported wheels
-          rm dist/*-linux*.whl
+          rm dist/*-ubuntu*.whl
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
           find dist -type d -empty -delete
           ls -R dist
           # convert linux wheels to manylinux format
-          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux1_x86_64 ls /io && auditwheel repair /io/*linux*.whl -w /io/
+          docker run --rm -v `pwd`/dist:/io -w /io quay.io/pypa/manylinux1_x86_64 auditwheel repair *.whl -w /io/
           # drop unsupported wheels
           rm dist/*-linux*.whl
       # retrieve your distributions here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,5 +117,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          repository-url: https://pypi.org/p/pc-ble-driver-py-com
+          repository-url: https://pypi.org/p/pc-ble-driver-py-com/
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
           find dist -type d -empty -delete
           ls -R dist
           # convert linux wheels to manylinux format
-          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*linux*.whl -w /io/
+          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux1_x86_64 auditwheel repair /io/*linux*.whl -w /io/
           # drop unsupported wheels
           rm dist/*-linux*.whl
       # retrieve your distributions here

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,14 +110,13 @@ jobs:
           path: dist
       - name: flatten folder structure
         run: |
-          ls -R dist
           find dist -name '*.whl' -exec mv {} dist \;
           find dist -type d -empty -delete
           ls -R dist
           # convert linux wheels to manylinux format
-          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*ubuntu*.whl -w /io/
+          docker run --rm -v `pwd`/dist:/io quay.io/pypa/manylinux2014_x86_64 auditwheel repair /io/*linux*.whl -w /io/
           # drop unsupported wheels
-          rm dist/*-ubuntu*.whl
+          rm dist/*-linux*.whl
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,9 @@ jobs:
         with:
           path: dist
       - name: flatten folder structure
-        run: find dist -name '*.whl' -exec cp {} dist \;
+        run: |
+          find dist -name '*.whl' -exec mv {} dist \;
+          find . -type d -empty -delete
       # retrieve your distributions here
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pc_ble_driver_py/__init__.py
+++ b/pc_ble_driver_py/__init__.py
@@ -38,4 +38,4 @@
 Package marker file.
 """
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
     long_description="A Python interface and library for pc-ble-driver. This allows Python applications to interface "
     "with a Nordic Semiconductor IC (both nRF51 and nRF52 series) over a serial port to obtain "
     "access to the full serialized SoftDevice API.",
+    long_description_content_type='text/plain'
     url="https://github.com/NordicSemiconductor/pc-ble-driver-py",
     license="Modified BSD License",
     author="Nordic Semiconductor ASA",

--- a/setup.py
+++ b/setup.py
@@ -96,14 +96,14 @@ setup(
         "License :: Other/Proprietary License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="nordic nrf51 nrf52 ble bluetooth softdevice serialization bindings pc-ble-driver pc-ble-driver-py "
     "pc_ble_driver pc_ble_driver_py",
-    python_requires=">=3.7, <3.11",
+    python_requires=">3.7, <=3.11",
     install_requires=requirements,
     packages=packages,
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def find_version(*file_paths):
 packages = find_packages(exclude=["tests*"])
 
 setup(
-    name="pc_ble_driver_py",
+    name="pc_ble_driver_py_com",
     version=find_version("pc_ble_driver_py", "__init__.py"),
     description="Python bindings for the Nordic pc-ble-driver SoftDevice serialization library",
     long_description="A Python interface and library for pc-ble-driver. This allows Python applications to interface "

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     long_description="A Python interface and library for pc-ble-driver. This allows Python applications to interface "
     "with a Nordic Semiconductor IC (both nRF51 and nRF52 series) over a serial port to obtain "
     "access to the full serialized SoftDevice API.",
-    long_description_content_type='text/plain'
+    long_description_content_type="text/plain",
     url="https://github.com/NordicSemiconductor/pc-ble-driver-py",
     license="Modified BSD License",
     author="Nordic Semiconductor ASA",


### PR DESCRIPTION
introduce release flow that publish wheels to pypi and GitHub release assets

**NOTE:** linux wheels are not yet manylinux compatible and therefore cannot be published yet to pypi. needs more work in follow up PR