### PR TITLE
ble_adapter: Increase wait timeout to 8s

### DIFF
--- a/pc_ble_driver_py/ble_adapter.py
+++ b/pc_ble_driver_py/ble_adapter.py
@@ -150,7 +150,7 @@ class EvtSync(object):
             self.conds[evt] = Condition(Lock())
         self.data = None
 
-    def wait(self, evt, timeout=5):
+    def wait(self, evt, timeout=8):
         self.data = None
         with self.conds[evt]:
             self.conds[evt].wait(timeout=timeout)


### PR DESCRIPTION
When longer than 5 seconds supervision timeout was used, wait() timeout triggered before supervision timeout which lead to situation that weird exceptions were thrown because pc-ble-driver-py did not receive response in time because the connection was just about to be lost.

Snippet from exception:
  File "/usr/local/lib/python3.10/site-packages/pc_ble_driver_py/ble_driver.py", line 104, in wrapper
    err_code = wrapped(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/pc_ble_driver_py/ble_adapter.py", line 512, in write_req
    return result["status"]
TypeError: 'NoneType' object is not subscriptable