### PR TITLE
Build using python limited API 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: pc-ble-driver-py
 
     - name: Checkout pc-ble-driver
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: NordicSemiconductor/pc-ble-driver
         ref: c0ffd419053e2405fffdb02ce7f1f9acceff4a66
@@ -47,7 +47,7 @@ jobs:
       run: brew install cmake swig asio spdlog
 
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -90,7 +90,7 @@ jobs:
         python setup.py bdist_wheel --build-type Release
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pc_ble_driver_py-${{ matrix.os }}-${{ matrix.toxpy}}
         path: "pc-ble-driver-py/dist/*.whl"
@@ -106,7 +106,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: dist
 
@@ -120,6 +120,6 @@ jobs:
           ls -R
 
       - name: upload release assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, macos-13, windows-2019 ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.10', '3.11' ]
         include:
-          - python-version: '3.8'
-            toxpy: py38
-          - python-version: '3.9'
-            toxpy: py39
           - python-version: '3.10'
             toxpy: py310
           - python-version: '3.11'
@@ -40,16 +36,11 @@ jobs:
 
     - name: Install linux dependencies
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y cmake build-essential libspdlog-dev libasio-dev libudev-dev
+      run: sudo apt-get update && sudo apt-get install -y build-essential libspdlog-dev libasio-dev libudev-dev
 
     - name: Install macos dependencies
       if: runner.os == 'macOS'
-      run: brew install cmake swig asio spdlog
-
-    - name: Setup python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      run: brew install asio spdlog
 
     - name: Install windows dependencies
       if: runner.os == 'Windows'
@@ -57,14 +48,16 @@ jobs:
         VCPKG_ROOT: C:\vcpkg
       run: |
         echo "VCPKG_ROOT=${{ env.VCPKG_ROOT }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        choco install cmake swig
         vcpkg install --triplet x64-windows asio spdlog
 
-    - name: toxify
-      working-directory: pc-ble-driver
-      run: |
-         python -m pip install scikit-build tox
-         tox -e ${{ matrix.toxpy }}
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Python dependencies
+      working-directory: pc-ble-driver-py
+      run: python -m pip install -r requirements-dev.txt
 
     - name: Compile pc-ble-driver
       if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-latest, windows-2019 ]
+        os: [ ubuntu-20.04, macos-13, windows-2019 ]
         python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         include:
           - python-version: '3.8'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.20)
 
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
     set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
@@ -6,6 +6,12 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 # Name of the project
 project (pc-ble-driver-py)
+if(WIN32)
+    # Hack for building with Python limited API
+    # scikit-build links with python3x.lib, but setting PY_LIMITED_API will request python3.lib through a #pragma comment(lib,"python3.lib") in pyconfig.h
+    # since only the .lib path is passed (and not a library search dir), the build will fail because the linker won't know where to find python3.lib
+    cmake_path(REPLACE_FILENAME PYTHON_LIBRARY python3.lib)
+endif()
 # PYTHON_LIBRARY is changed by the PythonExtensions package, so a different variable is required to keep the original user flag
 set(PYTHON_LIBRARY_FROM_USER_FLAGS "${PYTHON_LIBRARY}")
 # Use non-debug version of python, even when building a debug version 
@@ -40,7 +46,7 @@ set(NRF_BLE_DRIVER_VERSION "4.1.100")
 set(SD_API_VERS "2;5")
 
 # SWIG
-find_package(SWIG REQUIRED)
+find_package(SWIG 4.2.0 REQUIRED)
 include(${SWIG_USE_FILE})
 
 # nrf-ble-driver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja", "tox"]
+requires = ["setuptools", "wheel", "scikit-build", "cmake", "swig", "ninja", "tox"]
 
 [flake8]
 exclude = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 setuptools >= 54.1.2
 wheel == 0.36.2
 scikit-build ~= 0.11.1
-cmake >= 3.13.3
+cmake >= 3.20.3
+swig >= 4.2.0
 ninja ~= 1.9.0
 tox ~= 3.9.0
 unittest-xml-reporting==3.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+py_limited_api=cp34

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     ],
     keywords="nordic nrf51 nrf52 ble bluetooth softdevice serialization bindings pc-ble-driver pc-ble-driver-py "
     "pc_ble_driver pc_ble_driver_py",
-    python_requires=">3.7, <=3.11",
+    python_requires=">=3.7",
     install_requires=requirements,
     packages=packages,
     package_data={

--- a/swig/pc_ble_driver.i.in
+++ b/swig/pc_ble_driver.i.in
@@ -37,6 +37,10 @@
 
 %module @SWIG_MODULE_NAME@
 
+%begin %{
+#define Py_LIMITED_API 0x03040000
+%}
+
 #ifdef _MSC_VER
     #if _MSC_VER == 1500 // 1500 == VC+ 9.0
         #include "stdint.h"


### PR DESCRIPTION
SWIG version 4.2.0 and up supports building using the Python limited API
This provides binary wheels with stable ABI that will work with any
python 3 version >= 3.4 (including future unreleased versions)