### PR TITLE
add macOS builds (arm + x86_64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,13 @@ jobs:
         include:
           - python-version: '3.10'
             toxpy: py310
+            macos-python-version: '3.10.9'
           - python-version: '3.11'
             toxpy: py311
+            macos-python-version: '3.11.9'
           - python-version: '3.12'
             toxpy: py312
+            macos-python-version: '3.12.7'
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -54,8 +57,16 @@ jobs:
 
     - name: Setup python
       uses: actions/setup-python@v5
+      if: matrix.os != 'macos-13'
       with:
         python-version: ${{ matrix.python-version }}
+        
+    - name: Setup python for macos
+      if: matrix.os == 'macos-13'
+      run: |
+        curl -s https://www.python.org/ftp/python/${{ matrix.macos-python-version }}/python-${{ matrix.macos-python-version }}-macos11.pkg --output python.pkg
+        sudo installer -pkg python.pkg -target /
+        echo "/Library/Frameworks/Python.framework/Versions/${{ matrix.macos-python-version }}/bin" >> $GITHUB_PATH
 
     - name: Install Python dependencies
       working-directory: pc-ble-driver-py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
         curl -s https://www.python.org/ftp/python/${{ matrix.macos-python-version }}/python-${{ matrix.macos-python-version }}-macos11.pkg --output python.pkg
         sudo installer -pkg python.pkg -target /
         echo "/Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin" >> $GITHUB_PATH
+        pip3 install --upgrade pip
 
     - name: Install Python dependencies
       working-directory: pc-ble-driver-py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-13, windows-2019 ]
+        os: [ ubuntu-20.04, macos-13, macos-13-arm64, windows-2019 ]
         python-version: [ '3.10', '3.11', '3.12' ]
         include:
           - python-version: '3.10'
@@ -57,12 +57,12 @@ jobs:
 
     - name: Setup python
       uses: actions/setup-python@v5
-      if: matrix.os != 'macos-13'
+      if: "! contains(matrix.os, 'macos')"
       with:
         python-version: ${{ matrix.python-version }}
         
     - name: Setup python for macos
-      if: matrix.os == 'macos-13'
+      if: contains(matrix.os, 'macos')
       run: |
         curl -s https://www.python.org/ftp/python/${{ matrix.macos-python-version }}/python-${{ matrix.macos-python-version }}-macos11.pkg --output python.pkg
         sudo installer -pkg python.pkg -target /

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Checkout pc-ble-driver
       uses: actions/checkout@v4
       with:
-        repository: embedded-community/pc-ble-driver-py
+        repository: embedded-community/pc-ble-driver
         ref: 508273d3ef7e71f1678b2874ba80c2fd0bb2874f
         path: pc-ble-driver
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,9 @@ jobs:
         curl -s https://www.python.org/ftp/python/${{ matrix.macos-python-version }}/python-${{ matrix.macos-python-version }}-macos11.pkg --output python.pkg
         sudo installer -pkg python.pkg -target /
         echo "/Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin" >> $GITHUB_PATH
-        pip3 install --upgrade pip
+        python3 --version
+        python${{ matrix.python-version }} --version
+        pip${{ matrix.python-version }} install --upgrade pip
 
     - name: Install Python dependencies
       working-directory: pc-ble-driver-py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,12 @@ jobs:
         PYTHON_PATH=$(ls /Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin/python3)
     
         # Create a symbolic link to the installed Python version
+        which python3
         sudo ln -sf $PYTHON_PATH /usr/local/bin/python3
         sudo ln -sf $PYTHON_PATH /usr/local/bin/
+
+        # Add /usr/local/bin to the PATH to ensure it takes precedence
+        echo "/usr/local/bin" >> $GITHUB_PATH
         
         python3 --version
         pip3 install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: embedded-community/pc-ble-driver
-        ref: 508273d3ef7e71f1678b2874ba80c2fd0bb2874f
+        ref: fdbf92831badbca016d2bf95da6fab056ef2d931
         path: pc-ble-driver
 
     - name: Install linux dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Install Python dependencies
       working-directory: pc-ble-driver-py
-      run: python -m pip install -r requirements-dev.txt
+      run: python3 -m pip install -r requirements-dev.txt
 
     - name: Compile pc-ble-driver
       if: runner.os != 'Windows'
@@ -94,13 +94,13 @@ jobs:
       if: runner.os != 'Windows'
       working-directory: pc-ble-driver-py
       run: |
-        python setup.py bdist_wheel --build-type Release
+        python3 setup.py bdist_wheel --build-type Release
 
     - name: Build pc-ble-driver-py wheels windows
       if: runner.os == 'Windows'
       working-directory: pc-ble-driver-py
       run: |
-        python setup.py bdist_wheel --build-type Release -G "Visual Studio 16 2019" --skip-generator-test
+        python3 setup.py bdist_wheel --build-type Release -G "Visual Studio 16 2019" --skip-generator-test
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
         PATH=/usr/local/bin:$PATH
         python3 --version
         pip3 install --upgrade pip
+        # install explicitly
+        pip3 install scikit-build~=0.18.1
 
     - name: Install Python dependencies
       working-directory: pc-ble-driver-py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,15 @@ jobs:
       run: |
         curl -s https://www.python.org/ftp/python/${{ matrix.macos-python-version }}/python-${{ matrix.macos-python-version }}-macos11.pkg --output python.pkg
         sudo installer -pkg python.pkg -target /
-        echo "/Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin" >> $GITHUB_PATH
+        # Find the path of the newly installed Python
+        PYTHON_PATH=$(ls /Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin/python3)
+    
+        # Create a symbolic link to the installed Python version
+        sudo ln -sf $PYTHON_PATH /usr/local/bin/python3
+        sudo ln -sf $PYTHON_PATH /usr/local/bin/
+        
         python3 --version
-        python${{ matrix.python-version }} --version
-        pip${{ matrix.python-version }} install --upgrade pip
+        pip3 install --upgrade pip
 
     - name: Install Python dependencies
       working-directory: pc-ble-driver-py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,11 @@ jobs:
       working-directory: pc-ble-driver
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DDISABLE_TESTS=1 -DNRF_BLE_DRIVER_VERSION=${{ env.NRF_BLE_DRIVER_VERSION }} -G "Unix Makefiles" ..
+        cmake_args="-DCMAKE_BUILD_TYPE=Release -DDISABLE_TESTS=1 -DNRF_BLE_DRIVER_VERSION=${{ env.NRF_BLE_DRIVER_VERSION }}"
+        if [[ "${{ matrix.os }}" == "macos-14" ]]; then
+          cmake_args="$cmake_args -DARCH=arm64"
+        fi
+        cmake $cmake_args -G "Unix Makefiles" ..
         make nrf_ble_driver_sd_api_v5_static
         sudo make install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-13, macos-13-arm64, windows-2019 ]
+        os: [ ubuntu-20.04, macos-13, macos-14, windows-2019 ]
         python-version: [ '3.10', '3.11', '3.12' ]
         include:
           - python-version: '3.10'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Checkout pc-ble-driver
       uses: actions/checkout@v4
       with:
-        repository: NordicSemiconductor/pc-ble-driver
-        ref: c0ffd419053e2405fffdb02ce7f1f9acceff4a66
+        repository: embedded-community/pc-ble-driver-py
+        ref: 508273d3ef7e71f1678b2874ba80c2fd0bb2874f
         path: pc-ble-driver
 
     - name: Install linux dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         curl -s https://www.python.org/ftp/python/${{ matrix.macos-python-version }}/python-${{ matrix.macos-python-version }}-macos11.pkg --output python.pkg
         sudo installer -pkg python.pkg -target /
-        echo "/Library/Frameworks/Python.framework/Versions/${{ matrix.macos-python-version }}/bin" >> $GITHUB_PATH
+        echo "/Library/Frameworks/Python.framework/Versions/${{ matrix.python-version }}/bin" >> $GITHUB_PATH
 
     - name: Install Python dependencies
       working-directory: pc-ble-driver-py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,9 +74,10 @@ jobs:
         sudo ln -sf $PYTHON_PATH /usr/local/bin/python3
         sudo ln -sf $PYTHON_PATH /usr/local/bin/
 
-        # Add /usr/local/bin to the PATH to ensure it takes precedence
-        echo "/usr/local/bin" >> $GITHUB_PATH
-        
+        # Prepend /usr/local/bin to PATH to override any default Homebrew paths
+        echo "PATH=/usr/local/bin:$PATH" >> $GITHUB_ENV
+
+        PATH=/usr/local/bin:$PATH
         python3 --version
         pip3 install --upgrade pip
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ wheel == 0.36.2
 scikit-build ~= 0.18.1
 cmake >= 3.20.3
 swig >= 4.2.0
-ninja ~= 1.9.0
+ninja ~= 1.11.1.1
 tox ~= 3.9.0


### PR DESCRIPTION
make macOS builds working.  macOS-13 is x86_64 build and macOS-14 is arm64 build.

NOTE: since Nordic is officially deprecated pc-ble-driver -library, decide to fork it here: https://github.com/embedded-community/pc-ble-driver