### PR TITLE
use only lowest python wheels in release asset to make it working all python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,12 +57,12 @@ jobs:
 
     - name: Setup python
       uses: actions/setup-python@v5
-      if: "! contains(matrix.os, 'macos')"
+      if: runner.os != 'macOS'
       with:
         python-version: ${{ matrix.python-version }}
         
     - name: Setup python for macos
-      if: contains(matrix.os, 'macos')
+      if: runner.os == 'macOS'
       run: |
         curl -s https://www.python.org/ftp/python/${{ matrix.macos-python-version }}/python-${{ matrix.macos-python-version }}-macos11.pkg --output python.pkg
         sudo installer -pkg python.pkg -target /
@@ -150,12 +150,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v5
-        if: "! contains(matrix.os, 'macos')"
+        if: runner.os != 'macOS'
         with:
           python-version: ${{ matrix.python-version }}
           
       - name: Setup python for macos
-        if: contains(matrix.os, 'macos')
+        if: runner.os == 'macOS'
         run: |
           curl -s https://www.python.org/ftp/python/${{ matrix.macos-python-version }}/python-${{ matrix.macos-python-version }}-macos11.pkg --output python.pkg
           sudo installer -pkg python.pkg -target /
@@ -202,6 +202,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
+          pattern: pc_ble_driver_py-*-py310-*
 
       - name: flatten folder structure
         working-directory: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, macos-13, macos-14, windows-2019 ]
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
         include:
+          - python-version: '3.9'
+            toxpy: py39
+            macos-python-version: '3.9.12'
           - python-version: '3.10'
             toxpy: py310
             macos-python-version: '3.10.9'
@@ -133,8 +136,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, macos-13, macos-14, windows-2019 ]
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
         include:
+          - python-version: '3.9'
+            toxpy: py39
+            macos-python-version: '3.9.12'
           - python-version: '3.10'
             toxpy: py310
             macos-python-version: '3.10.9'
@@ -202,7 +208,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
-          pattern: pc_ble_driver_py-*-py310-*
+          pattern: pc_ble_driver_py-*-py39-*
 
       - name: flatten folder structure
         working-directory: dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-py_limited_api = cp38
+py_limited_api=cp38

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,1 +1,2 @@
 [bdist_wheel]
+py_limited_api = cp38

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,1 @@
 [bdist_wheel]
-py_limited_api=cp34


### PR DESCRIPTION
Trying to get working wheels on macOS and 3.12